### PR TITLE
unify environment detection

### DIFF
--- a/index.js
+++ b/index.js
@@ -28,18 +28,24 @@
 
   'use strict';
 
+  var util = {inspect: {}};
+
   /* istanbul ignore else */
   if (typeof module === 'object' && typeof module.exports === 'object') {
-    module.exports = f (require ('sanctuary-show'),
+    module.exports = f (require ('util'),
+                        require ('sanctuary-show'),
                         require ('sanctuary-type-classes'));
   } else if (typeof define === 'function' && define.amd != null) {
-    define (['sanctuary-show', 'sanctuary-type-classes'], f);
+    define (['sanctuary-show', 'sanctuary-type-classes'], function(show, Z) {
+      return f (util, show, Z);
+    });
   } else {
-    self.sanctuaryDescending = f (self.sanctuaryShow,
+    self.sanctuaryDescending = f (util,
+                                  self.sanctuaryShow,
                                   self.sanctuaryTypeClasses);
   }
 
-} (function(show, Z) {
+} (function(util, show, Z) {
 
   'use strict';
 
@@ -73,15 +79,13 @@
     /* eslint-enable key-spacing */
   };
 
-  var util =
-    typeof module === 'object' && typeof module.exports === 'object' ?
-    require ('util') :
-    /* istanbul ignore next */ {};
-  prototype[
-    util.inspect != null && typeof util.inspect.custom === 'symbol' ?
-    /* istanbul ignore next */ util.inspect.custom :
-    /* istanbul ignore next */ 'inspect'
-  ] = Descending$prototype$show;
+  var custom = util.inspect.custom;
+  /* istanbul ignore else */
+  if (typeof custom === 'symbol') {
+    prototype[custom] = Descending$prototype$show;
+  } else {
+    prototype.inspect = Descending$prototype$show;
+  }
 
   //. ```javascript
   //. > S.sort ([5, 1, 2])


### PR DESCRIPTION
Having `typeof module === 'object' && typeof module.exports === 'object'` in two places doesn't feel right. In CommonJS settings, providing `require ('util')` as a dependency is straightforward. I spent some time reading about [AMD][1] and creating a dummy project to see whether we can define and depend on a `sanctuary-descending#util` module. We can. I used this “namespaced” module name to avoid collisions, as my understanding is that module names share a single namespace.

I'd appreciate a review from a member of the community who has actually *used* AMD. :)


[1]: https://requirejs.org/
